### PR TITLE
ApplicationContextAware

### DIFF
--- a/spring-learning/src/main/java/spring/learning/video/three/Triangle.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/Triangle.java
@@ -1,12 +1,18 @@
 package spring.learning.video.three;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
 import java.util.List;
 
-public class Triangle {
+public class Triangle implements ApplicationContextAware, BeanNameAware {
 
     private Point pointA;
     private Point pointB;
     private Point pointC;
+    private ApplicationContext context = null;
 
     public Point getPointA() {
         return pointA;
@@ -38,4 +44,14 @@ public class Triangle {
         System.out.println("Point C = (" + getPointC().getX() + ", " + getPointC().getY() + ")");
     }
 
+    @Override
+    public void setApplicationContext(ApplicationContext context)
+            throws BeansException {
+        this.context = context;
+    }
+
+    @Override
+    public void setBeanName(String beanName) {
+        System.out.println("Bean name is: " + beanName);
+    }
 }


### PR DESCRIPTION
Why? When you need ApplicationContext inside a class
Creates method setApplicationContext(inside Triangle class)
Interface BeanNameAware- set the name of the bean. #7