### PR TITLE
The Autowired Annotation

### DIFF
--- a/spring-learning/src/main/java/spring/learning/video/three/Circle.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/Circle.java
@@ -1,6 +1,7 @@
 package spring.learning.video.three;
 
-import org.springframework.beans.factory.annotation.Required;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public class Circle implements Shape {
 
@@ -16,7 +17,8 @@ public class Circle implements Shape {
         return center;
     }
 
-    @Required
+    @Autowired
+    @Qualifier("circleRelated")
     public void setCenter(Point center) {
         this.center = center;
     }

--- a/spring-learning/src/main/resources/spring.xml
+++ b/spring-learning/src/main/resources/spring.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!--<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">-->
 
-
-<beans>
-    <bean id="triangle" class="spring.learning.video.three.Triangle">
-        <property name="pointA" ref="pointA" />
-        <property name="pointB" ref="pointB" />
-        <property name="pointC" ref="pointC" />
-    </bean>
-    <bean id="pointA" class="spring.learning.video.three.Point">
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <!--    <bean id="triangle" class="spring.learning.video.three.Triangle">-->
+    <!--        <property name="pointA" ref="pointA" />-->
+    <!--        <property name="pointB" ref="pointB" />-->
+    <!--        <property name="pointC" ref="pointC" />-->
+    <!--    </bean>-->
+    <bean id="center" class="spring.learning.video.three.Point">
+        <qualifier value="circleRelated" />
         <property name="x" value="0" />
         <property name="y" value="0" />
     </bean>
@@ -21,7 +26,8 @@
         <property name="y" value="0" />
     </bean>
     <bean id="circle" class="spring.learning.video.three.Circle">
-        <property name="center" ref="pointA" />
     </bean>
-    <bean class="org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor" />
+    <context:annotation-config />
+<!--    <bean class="org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor" />-->
+<!--    <bean class="org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor" />-->
 </beans>


### PR DESCRIPTION
Similiar to autowire by type
Let Spring order wire the dependency into the required member
Don't need to specify a property because dependency wiring information is specified using @Autowired (if only have 1 bean)
@Autowired annotation first looks for type
If finds multiple beans of the same type, spring it's gonna look for clues in bean name. (intelligent guesswork)
@Qualifer annotation
Is something to mention in the bean definition to say that this bean is related
Spring will verify after name checking, the qualifier.
XML namespaces.
<context:annotation-config /> - shortcut for defining all annotation processor(no need to import them) like " <bean class="org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor" />"
Autowired checks - type, after that name. #7