### PR TITLE
Component and Stereotype Annotations

### DIFF
--- a/spring-learning/src/main/java/spring/learning/video/three/Circle.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/Circle.java
@@ -1,9 +1,12 @@
 package spring.learning.video.three;
 
+import org.springframework.stereotype.Component;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
 
+@Component
 public class Circle implements Shape {
 
     private Point center;

--- a/spring-learning/src/main/resources/spring.xml
+++ b/spring-learning/src/main/resources/spring.xml
@@ -11,7 +11,7 @@
     <!--        <property name="pointB" ref="pointB" />-->
     <!--        <property name="pointC" ref="pointC" />-->
     <!--    </bean>-->
-    <bean id="center" class="spring.learning.video.three.Point">
+    <bean id="pointA" class="spring.learning.video.three.Point">
         <qualifier value="circleRelated" />
         <property name="x" value="0" />
         <property name="y" value="0" />
@@ -24,7 +24,6 @@
         <property name="x" value="20" />
         <property name="y" value="0" />
     </bean>
-    <bean id="circle" class="spring.learning.video.three.Circle">
-    </bean>
     <context:annotation-config />
+    <context:component-scan base-package="spring.learning.video.three" />
 </beans>


### PR DESCRIPTION
@Component - defines Circle class as a Spring bean
@Component equals a <bean></bean>
When you declare a class with @Component, we don't need to declare <bean></bean> of that class
If we don't specify name in @Component, the Spring will see that class as a bean with class name(all lower cases)
<context:component-scan base-package="spring.learning.video.three" />
Spring will scan only the specified package
Stereotypes when you write enterprise applications in spring you would have some standard spring beans that perform some standard rules
A data object, A service class, A view, A controller - stereotypical rules that spring beans perform
Spring has some annotations that let us define a particular bean to do one of above rules