### PR TITLE
MessageSource

### DIFF
--- a/spring-learning/src/main/java/spring/learning/video/three/Circle.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/Circle.java
@@ -1,5 +1,7 @@
 package spring.learning.video.three;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -10,29 +12,41 @@ import javax.annotation.Resource;
 public class Circle implements Shape {
 
     private Point center;
+    @Autowired
+    private MessageSource messageSource;
 
     @Override
     public void draw() {
-        System.out.println("Drawing Circle");
-        System.out.println("Circle: Point is: (" + center.getX() + ", " + center.getY() +")");
+        System.out.println(this.messageSource.getMessage("drawing.circle", null, "Default Drawing Circle", null));
+        System.out.println(this.messageSource.getMessage("drawing.point", new Object[] {center.getX(), center.getY()}, "Default Point Message", null));
+//        System.out.println("Circle: Point is: (" + center.getX() + ", " + center.getY() +")");
+        System.out.println(this.messageSource.getMessage("greeting", null, "Default Greeting", null));
     }
 
     public Point getCenter() {
         return center;
     }
 
-    @Resource(name = "pointC")
+    @Resource
     public void setCenter(Point center) {
         this.center = center;
     }
 
-    @PostConstruct
-    public void initializeCircle() {
-        System.out.println("Init of Circle");
+    public MessageSource getMessageSource() {
+        return messageSource;
     }
 
-    @PreDestroy
-    public void destroyCircle() {
-        System.out.println("Destroy of Circle");
+    public void setMessageSource(MessageSource messageSource) {
+        this.messageSource = messageSource;
     }
+
+//    @PostConstruct
+//    public void initializeCircle() {
+//        System.out.println("Init of Circle");
+//    }
+//
+//    @PreDestroy
+//    public void destroyCircle() {
+//        System.out.println("Destroy of Circle");
+//    }
 }

--- a/spring-learning/src/main/java/spring/learning/video/three/DrawingApp.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/DrawingApp.java
@@ -8,8 +8,7 @@ public class DrawingApp {
 
     public static void main(String[] args) {
 
-        AbstractApplicationContext context = new ClassPathXmlApplicationContext("spring.xml");
-        context.registerShutdownHook();
+        ApplicationContext context = new ClassPathXmlApplicationContext("spring.xml");
         Shape shape = (Shape) context.getBean("circle");
         shape.draw();
     }

--- a/spring-learning/src/main/resources/mymessages.properties
+++ b/spring-learning/src/main/resources/mymessages.properties
@@ -1,0 +1,3 @@
+greeting=Hello!
+drawing.circle=Drawing Circle!
+drawing.point=Circle: Point is: ({0}, {1})

--- a/spring-learning/src/main/resources/spring.xml
+++ b/spring-learning/src/main/resources/spring.xml
@@ -20,9 +20,16 @@
         <property name="x" value="-20" />
         <property name="y" value="0" />
     </bean>
-    <bean id="pointC" class="spring.learning.video.three.Point">
+    <bean id="center" class="spring.learning.video.three.Point">
         <property name="x" value="20" />
         <property name="y" value="0" />
+    </bean>
+    <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
+        <property name="basenames">
+            <list>
+                <value>mymessages</value>
+            </list>
+        </property>
     </bean>
     <context:annotation-config />
     <context:component-scan base-package="spring.learning.video.three" />


### PR DESCRIPTION
Keep all messages in a property file and refer to those texts inside the property file
Spring provides support for that.
Can have a file which consolidates all these key and value pairs and then you specify the key itself in your app and refer to the text which is assigned to that key in property file.
Added mymessages.properties
Add key value pairs to store text messages
E. g. greeting=Hello!
We need to define mymessages.properties as a bean (class="org.springframework.context.support.ResourceBundleMessageSource")
We did injection for messageSource in Circle.java
({0}, {1})(in mymessages.prop) - placeholders for argument arg1 in "this.message.getMessage(arg0, arg1, arg2, arg3)(in Circle.java)" - which is an array of Object
arg1 = new Object[] {center.getX(), center.getY()} #7 