### PR TITLE
Event Handling in Spring

### DIFF
--- a/spring-learning/src/main/java/spring/learning/video/three/Circle.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/Circle.java
@@ -1,6 +1,8 @@
 package spring.learning.video.three;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
@@ -9,9 +11,10 @@ import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
 
 @Component
-public class Circle implements Shape {
+public class Circle implements Shape, ApplicationEventPublisherAware {
 
     private Point center;
+    private ApplicationEventPublisher publisher;
     @Autowired
     private MessageSource messageSource;
 
@@ -19,8 +22,8 @@ public class Circle implements Shape {
     public void draw() {
         System.out.println(this.messageSource.getMessage("drawing.circle", null, "Default Drawing Circle", null));
         System.out.println(this.messageSource.getMessage("drawing.point", new Object[] {center.getX(), center.getY()}, "Default Point Message", null));
-//        System.out.println("Circle: Point is: (" + center.getX() + ", " + center.getY() +")");
-        System.out.println(this.messageSource.getMessage("greeting", null, "Default Greeting", null));
+        DrawEvent drawEvent = new DrawEvent(this);
+        publisher.publishEvent(drawEvent);
     }
 
     public Point getCenter() {
@@ -40,13 +43,18 @@ public class Circle implements Shape {
         this.messageSource = messageSource;
     }
 
-//    @PostConstruct
-//    public void initializeCircle() {
-//        System.out.println("Init of Circle");
-//    }
-//
-//    @PreDestroy
-//    public void destroyCircle() {
-//        System.out.println("Destroy of Circle");
-//    }
+    @PostConstruct
+    public void initializeCircle() {
+        System.out.println("Init of Circle");
+    }
+
+    @PreDestroy
+    public void destroyCircle() {
+        System.out.println("Destroy of Circle");
+    }
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+        this.publisher = publisher;
+    }
 }

--- a/spring-learning/src/main/java/spring/learning/video/three/DrawEvent.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/DrawEvent.java
@@ -1,0 +1,12 @@
+package spring.learning.video.three;
+
+import org.springframework.context.ApplicationEvent;
+
+public class DrawEvent extends ApplicationEvent {
+    public DrawEvent(Object source) {
+        super(source);
+    }
+    public String toString() {
+        return "Draw Event Occured";
+    }
+}

--- a/spring-learning/src/main/java/spring/learning/video/three/MyEventListener.java
+++ b/spring-learning/src/main/java/spring/learning/video/three/MyEventListener.java
@@ -1,0 +1,13 @@
+package spring.learning.video.three;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyEventListener implements ApplicationListener {
+    @Override
+    public void onApplicationEvent(ApplicationEvent event) {
+        System.out.println(event.toString());
+    }
+}


### PR DESCRIPTION
Three core elements when it comes to event handling(not just Spring, generally)
Event Publisher - the entity which publishes the event
Event Listener - the entity which is actually listening for the event
Event Itself - it's a class that contains information about the event which the publisher publishes and listener listens to
In case of Spring, event handling there are interfaces
Spring provides an application listener interface, publisher interface
Added MyEventListener.java
We have to declare it with @Component (to declare as a bean, to register as a valie event listener)
To write your own event:
	-need to write own event class(or use an existing one)
	-need to have that event published in one of other beans
Added DrawEvent
Has to extend ApplicationEvent (it's the base event class that spring provides)
ApplicationEventPublisher is an interface(from Spring) that publishes events #7