### PR TITLE
Writing the Model Class with Annotations

### DIFF
--- a/library-backend/library-hibernate/pom.xml
+++ b/library-backend/library-hibernate/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>library-backend</artifactId>
+        <groupId>org.internship</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>library-hibernate</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>21.1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.6.0.Final</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/library-backend/library-hibernate/src/main/java/org/internship/hibernate/dto/UserDetails.java
+++ b/library-backend/library-hibernate/src/main/java/org/internship/hibernate/dto/UserDetails.java
@@ -1,0 +1,30 @@
+package org.internship.hibernate.dto;
+
+import org.hibernate.annotations.Table;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class UserDetails {
+
+    @Id
+    private int userId;
+    private String userName;
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+}

--- a/library-backend/library-hibernate/src/main/java/org/internship/hibernate/test/HibernateTest.java
+++ b/library-backend/library-hibernate/src/main/java/org/internship/hibernate/test/HibernateTest.java
@@ -1,0 +1,20 @@
+package org.internship.hibernate.test;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.internship.hibernate.dto.UserDetails;
+
+public class HibernateTest {
+    public static void main(String[] args) {
+        UserDetails user = new UserDetails();
+        user.setUserId(1);
+        user.setUserName("First User");
+
+        SessionFactory sessionFactory = new Configuration().configure().buildSessionFactory();
+        Session session = sessionFactory.openSession();
+        session.beginTransaction();
+        session.save(user);
+        session.getTransaction().commit();
+    }
+}

--- a/library-backend/library-hibernate/src/main/resources/hibernate.cfg.xml
+++ b/library-backend/library-hibernate/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <property name="connection.driver_class">oracle.jdbc.OracleDriver</property>
+        <property name="connection.url">jdbc:oracle:thin:@localhost:1521:ORCLCDB</property>
+        <property name="connection.username">SYS AS SYSDBA</property>
+        <property name="connection.password">Oradoc_db1</property>
+        <property name="dialect">org.hibernate.dialect.Oracle8iDialect</property>
+
+        <property name="hbm2ddl.auto">update</property>
+
+        <property name="show_sql">true</property>
+
+        <mapping class="org.internship.hibernate.dto.UserDetails" />
+
+    </session-factory>
+</hibernate-configuration>

--- a/library-backend/pom.xml
+++ b/library-backend/pom.xml
@@ -15,5 +15,6 @@
         <module>library-api</module>
         <module>library-impl</module>
         <module>library-app</module>
+        <module>library-hibernate</module>
     </modules>
 </project>


### PR DESCRIPTION
Added UserDetails.java, hibernate.cfg.xml
Dialect it's a configuration that you specify so that Hibernate knows what kind of language needs to use to talk to DB
(e. g. Postgres has different SQL queries than Oracle)
Show SQL - will print all the SQL that generates
hbm2ddl.auto - create
create the database schema required to save those model objects, we don't have to create the tables ourselves
<mapping></mapping>
Names the annotates entity class
List out all the model classes that we have configured
@Entity - tell Hibernate to treat this class as an entity class
@Id - This field will be the primary key
Saving Objects using Hibernate APIs

Added HibernateTest.java
Save the object in data base using Hibernate API service itself

Using the Hibernate API
Create a session factory - creates a session from session factory, use this session to save
Session Factory is created out of the configuration that we've already done
Create a session from the session factory
Use the session to save model objects
Transaction - create as many objects as I can