### PR TITLE
Configuring Collections and Adding Keys

### DIFF
--- a/library-backend/library-hibernate/src/main/java/org/internship/hibernate/dto/UserDetails.java
+++ b/library-backend/library-hibernate/src/main/java/org/internship/hibernate/dto/UserDetails.java
@@ -1,12 +1,21 @@
 package org.internship.hibernate.dto;
 
+import org.hibernate.annotations.CollectionId;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -19,7 +28,12 @@ public class UserDetails {
     private int userId;
     private String userName;
     @ElementCollection
-    private Set<Address> listOfAddresses = new HashSet<>();
+    @JoinTable(name="USER_ADDRESS",
+                        joinColumns = @JoinColumn(name="USER_ID")
+    )
+    @GenericGenerator(name="sequence-gen",strategy="sequence")
+    @CollectionId(columns = {@Column(name = "ADDRESS_ID")}, generator = "sequence", type = @Type(type = "long"))
+    private Collection<Address> listOfAddresses = new ArrayList<>();
 
     public int getUserId() {
         return userId;
@@ -37,11 +51,11 @@ public class UserDetails {
         this.userName = userName;
     }
 
-    public Set<Address> getListOfAddresses() {
+    public Collection<Address> getListOfAddresses() {
         return listOfAddresses;
     }
 
-    public void setListOfAddresses(Set<Address> listOfAddresses) {
+    public void setListOfAddresses(Collection<Address> listOfAddresses) {
         this.listOfAddresses = listOfAddresses;
     }
 }

--- a/library-backend/library-hibernate/src/main/java/org/internship/hibernate/test/HibernateTest.java
+++ b/library-backend/library-hibernate/src/main/java/org/internship/hibernate/test/HibernateTest.java
@@ -36,7 +36,6 @@ public class HibernateTest {
         UserDetails user2 = new UserDetails();
         user2.setUserId(2);
         user2.setUserName("SECOND USER");
-        user2.setOfficeAddress(address);
         /**
          * .configure() - uses the hibernate.cfg.xml configuration file
          * .buildSessionFactory() - builds a session


### PR DESCRIPTION
@JoinTable(name="USER_ADDRESS")
@JoinColumn(name="USER_ID")
@CollectionId - it's not a JPA Annotation,
@CollectionId(columns = { }, generator = , type = )
columns - column to primary key
generator - how to generate the primary key
type - the type of primary key
@GenericGenerator(name="hilo-gen", strategy = "hilo") - common generator type which hibernates provides
@Type(type=="long")
Hilo is not supported anymore, this should work - @GenericGenerator(name="sequence-gen",strategy="sequence")

#28